### PR TITLE
Add webhook service for Seerr/TorBox integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__
+*.pyc
+.env
+.git
+.gitignore
+tests/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# Torbox
+TORBOX_API_KEY=replace-me
+TORBOX_BASE_URL=https://api.torbox.app/v1/api
+
+# Torrentio. Optional opts segment (e.g. providers, sort) appended to base URL.
+TORRENTIO_BASE_URL=https://torrentio.strem.fun
+TORRENTIO_OPTS=
+
+# Jellyfin
+JELLYFIN_URL=http://10.0.0.10:8096
+JELLYFIN_API_KEY=
+
+# Listener
+LISTEN_HOST=0.0.0.0
+LISTEN_PORT=8088
+
+# Optional shared secret. If set, Seerr must send header X-Webhook-Secret: <value>
+# or use the query param ?secret=<value>.
+WEBHOOK_SECRET=
+
+# Quality preferences. Lower index = preferred. 4K excluded by default.
+QUALITY_PREFERENCE=1080p,720p
+ALLOW_4K=false
+
+# Torbox polling
+TORBOX_POLL_INTERVAL_SEC=10
+TORBOX_POLL_TIMEOUT_SEC=600
+
+LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    LISTEN_HOST=0.0.0.0 \
+    LISTEN_PORT=8088
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY *.py ./
+
+EXPOSE 8088
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD python -c "import urllib.request,os,sys; \
+urllib.request.urlopen(f'http://127.0.0.1:{os.environ.get(\"LISTEN_PORT\",\"8088\")}/health').read(); sys.exit(0)" || exit 1
+
+CMD ["sh", "-c", "gunicorn --bind ${LISTEN_HOST}:${LISTEN_PORT} --workers 2 --threads 4 --access-logfile - app:app"]

--- a/app.py
+++ b/app.py
@@ -1,0 +1,58 @@
+import logging
+import threading
+
+from flask import Flask, abort, jsonify, request
+
+import processor
+from config import LISTEN_HOST, LISTEN_PORT, WEBHOOK_SECRET, configure_logging
+from webhook_parser import IgnoreEvent, WebhookError, parse
+
+configure_logging()
+log = logging.getLogger("seerr-torbox")
+
+app = Flask(__name__)
+
+
+def _check_auth() -> None:
+    if not WEBHOOK_SECRET:
+        return
+    provided = request.headers.get("X-Webhook-Secret") or request.args.get("secret")
+    if provided != WEBHOOK_SECRET:
+        log.warning("Rejected webhook with bad/missing secret from %s", request.remote_addr)
+        abort(401)
+
+
+@app.get("/health")
+def health():
+    return jsonify(status="ok")
+
+
+@app.post("/webhook")
+def webhook():
+    _check_auth()
+    payload = request.get_json(silent=True) or {}
+    log.info("Received webhook: notification_type=%s subject=%s",
+             payload.get("notification_type"), payload.get("subject"))
+    try:
+        media_request = parse(payload)
+    except IgnoreEvent as exc:
+        log.info("Ignoring event: %s", exc)
+        return jsonify(status="ignored", reason=str(exc))
+    except WebhookError as exc:
+        log.error("Bad webhook payload: %s", exc)
+        return jsonify(status="error", error=str(exc)), 400
+
+    # Run the long-running fulfillment off the request thread so Seerr gets a fast 200.
+    thread = threading.Thread(
+        target=processor.process,
+        args=(media_request,),
+        name=f"process-{media_request.imdb_id}",
+        daemon=True,
+    )
+    thread.start()
+    return jsonify(status="accepted", imdb_id=media_request.imdb_id, title=media_request.title), 202
+
+
+if __name__ == "__main__":
+    log.info("Starting seerr-torbox webhook on %s:%d", LISTEN_HOST, LISTEN_PORT)
+    app.run(host=LISTEN_HOST, port=LISTEN_PORT)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,52 @@
+import logging
+import os
+
+
+def _env(name: str, default: str | None = None, required: bool = False) -> str:
+    value = os.environ.get(name, default)
+    if required and not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value or ""
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise RuntimeError(f"Environment variable {name} must be an integer, got {raw!r}") from exc
+
+
+TORBOX_API_KEY = _env("TORBOX_API_KEY", required=True)
+TORBOX_BASE_URL = _env("TORBOX_BASE_URL", "https://api.torbox.app/v1/api")
+
+TORRENTIO_BASE_URL = _env("TORRENTIO_BASE_URL", "https://torrentio.strem.fun")
+# Torrentio config string controls trackers/providers; the default is the public defaults.
+TORRENTIO_OPTS = _env("TORRENTIO_OPTS", "")
+
+JELLYFIN_URL = _env("JELLYFIN_URL", "http://10.0.0.10:8096")
+JELLYFIN_API_KEY = _env("JELLYFIN_API_KEY", "")
+
+LISTEN_HOST = _env("LISTEN_HOST", "0.0.0.0")
+LISTEN_PORT = _env_int("LISTEN_PORT", 8088)
+
+# Quality preferences. 4K is excluded by default per spec (HDD constraint).
+QUALITY_PREFERENCE = [q.strip() for q in _env("QUALITY_PREFERENCE", "1080p,720p").split(",") if q.strip()]
+ALLOW_4K = _env("ALLOW_4K", "false").lower() in ("1", "true", "yes")
+
+# How long to wait for Torbox to make the torrent available before triggering Jellyfin scan.
+TORBOX_POLL_INTERVAL_SEC = _env_int("TORBOX_POLL_INTERVAL_SEC", 10)
+TORBOX_POLL_TIMEOUT_SEC = _env_int("TORBOX_POLL_TIMEOUT_SEC", 600)
+
+WEBHOOK_SECRET = _env("WEBHOOK_SECRET", "")
+
+LOG_LEVEL = _env("LOG_LEVEL", "INFO").upper()
+
+
+def configure_logging() -> None:
+    logging.basicConfig(
+        level=getattr(logging, LOG_LEVEL, logging.INFO),
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  seerr-torbox-webhook:
+    build: .
+    image: seerr-torbox-webhook:latest
+    container_name: seerr-torbox-webhook
+    restart: unless-stopped
+    ports:
+      - "8088:8088"
+    env_file:
+      - .env
+    environment:
+      - LISTEN_HOST=0.0.0.0
+      - LISTEN_PORT=8088

--- a/jellyfin.py
+++ b/jellyfin.py
@@ -1,0 +1,24 @@
+import logging
+
+import requests
+
+from config import JELLYFIN_API_KEY, JELLYFIN_URL
+
+log = logging.getLogger(__name__)
+
+
+def refresh_library(timeout: int = 30) -> bool:
+    if not JELLYFIN_URL:
+        log.warning("JELLYFIN_URL not set; skipping library refresh")
+        return False
+    url = f"{JELLYFIN_URL.rstrip('/')}/Library/Refresh"
+    headers = {}
+    if JELLYFIN_API_KEY:
+        headers["X-Emby-Token"] = JELLYFIN_API_KEY
+    log.info("Triggering Jellyfin library refresh: %s", url)
+    resp = requests.post(url, headers=headers, timeout=timeout)
+    if resp.status_code >= 400:
+        log.error("Jellyfin refresh failed: %s %s", resp.status_code, resp.text[:200])
+        return False
+    log.info("Jellyfin library refresh accepted (%s)", resp.status_code)
+    return True

--- a/processor.py
+++ b/processor.py
@@ -1,0 +1,70 @@
+import logging
+
+import jellyfin
+import torbox
+import torrentio
+from webhook_parser import MediaRequest
+
+log = logging.getLogger(__name__)
+
+
+def _process_movie(req: MediaRequest) -> bool:
+    streams = torrentio.fetch_streams("movie", req.imdb_id)
+    best = torrentio.pick_best(streams)
+    if not best:
+        log.error("No suitable stream for movie %s (%s)", req.title, req.imdb_id)
+        return False
+    torbox.add_magnet(best.magnet)
+    torbox.wait_until_ready(best.info_hash)
+    return True
+
+
+def _process_season(req: MediaRequest, season: int) -> bool:
+    # First episode lookup to discover season packs.
+    streams = torrentio.fetch_streams("series", req.imdb_id, season=season, episode=1)
+    season_pack = torrentio.pick_best(streams, prefer_season_pack=True)
+    if season_pack and season_pack.is_season_pack:
+        log.info("Using season pack for %s S%02d", req.title, season)
+        torbox.add_magnet(season_pack.magnet)
+        torbox.wait_until_ready(season_pack.info_hash)
+        return True
+
+    log.info("No season pack for %s S%02d; falling back to per-episode", req.title, season)
+    added = 0
+    episode = 1
+    # Walk episodes until Torrentio returns nothing.
+    while True:
+        ep_streams = (
+            streams if episode == 1 else torrentio.fetch_streams("series", req.imdb_id, season=season, episode=episode)
+        )
+        if not ep_streams:
+            log.info("No more episodes returned at S%02dE%02d", season, episode)
+            break
+        best = torrentio.pick_best(ep_streams)
+        if best:
+            torbox.add_magnet(best.magnet)
+            torbox.wait_until_ready(best.info_hash)
+            added += 1
+        episode += 1
+        if episode > 50:  # safety cap
+            log.warning("Episode cap (50) reached for %s S%02d", req.title, season)
+            break
+    return added > 0
+
+
+def process(req: MediaRequest) -> bool:
+    log.info("Processing request: %s [%s] %s", req.title, req.media_type, req.imdb_id)
+    success = False
+    try:
+        if req.is_movie:
+            success = _process_movie(req)
+        else:
+            for season in req.seasons:
+                if _process_season(req, season):
+                    success = True
+    finally:
+        if success:
+            jellyfin.refresh_library()
+        else:
+            log.warning("No content added; skipping Jellyfin refresh for %s", req.title)
+    return success

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask==3.0.3
+requests==2.32.3
+gunicorn==22.0.0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,61 @@
+import os
+import sys
+
+os.environ.setdefault("TORBOX_API_KEY", "test")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+from webhook_parser import IgnoreEvent, WebhookError, parse
+
+
+def test_parse_movie_with_imdb():
+    payload = {
+        "notification_type": "MEDIA_AUTO_APPROVED",
+        "subject": "Dune (2024)",
+        "media": {"media_type": "movie", "imdbId": "tt15239678"},
+    }
+    req = parse(payload)
+    assert req.is_movie
+    assert req.imdb_id == "tt15239678"
+    assert req.title == "Dune (2024)"
+
+
+def test_parse_series_seasons():
+    payload = {
+        "notification_type": "MEDIA_APPROVED",
+        "subject": "Foundation",
+        "media": {"media_type": "tv", "imdbId": "tt0804484"},
+        "extra": [{"name": "Requested Seasons", "value": "1, 2"}],
+    }
+    req = parse(payload)
+    assert req.media_type == "series"
+    assert req.seasons == [1, 2]
+
+
+def test_imdb_in_extras():
+    payload = {
+        "notification_type": "MEDIA_AUTO_APPROVED",
+        "media": {"media_type": "movie"},
+        "extra": [{"name": "IMDb ID", "value": "tt0111161"}],
+    }
+    assert parse(payload).imdb_id == "tt0111161"
+
+
+def test_test_notification_ignored():
+    with pytest.raises(IgnoreEvent):
+        parse({"notification_type": "TEST_NOTIFICATION"})
+
+
+def test_missing_imdb():
+    with pytest.raises(WebhookError):
+        parse({"notification_type": "MEDIA_APPROVED", "media": {"media_type": "movie"}})
+
+
+def test_series_defaults_to_season_1():
+    payload = {
+        "notification_type": "MEDIA_APPROVED",
+        "media": {"media_type": "tv", "imdbId": "tt0903747"},
+    }
+    req = parse(payload)
+    assert req.seasons == [1]

--- a/torbox.py
+++ b/torbox.py
@@ -1,0 +1,78 @@
+import logging
+import time
+
+import requests
+
+from config import (
+    TORBOX_API_KEY,
+    TORBOX_BASE_URL,
+    TORBOX_POLL_INTERVAL_SEC,
+    TORBOX_POLL_TIMEOUT_SEC,
+)
+
+log = logging.getLogger(__name__)
+
+
+def _headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {TORBOX_API_KEY}"}
+
+
+def add_magnet(magnet: str, timeout: int = 30) -> dict:
+    url = f"{TORBOX_BASE_URL.rstrip('/')}/torrents/createtorrent"
+    log.info("Adding magnet to Torbox: %s", magnet[:80])
+    resp = requests.post(url, headers=_headers(), data={"magnet": magnet}, timeout=timeout)
+    resp.raise_for_status()
+    payload = resp.json() or {}
+    if not payload.get("success", False):
+        raise RuntimeError(f"Torbox add failed: {payload}")
+    log.info("Torbox createtorrent response: %s", payload.get("detail") or payload.get("data"))
+    return payload.get("data", {}) or {}
+
+
+def list_torrents(timeout: int = 30) -> list[dict]:
+    url = f"{TORBOX_BASE_URL.rstrip('/')}/torrents/mylist"
+    resp = requests.get(url, headers=_headers(), timeout=timeout)
+    resp.raise_for_status()
+    payload = resp.json() or {}
+    return payload.get("data", []) or []
+
+
+def _matches_hash(item: dict, info_hash: str) -> bool:
+    candidate = (item.get("hash") or "").lower()
+    return candidate == info_hash.lower()
+
+
+def find_by_hash(info_hash: str) -> dict | None:
+    for item in list_torrents():
+        if _matches_hash(item, info_hash):
+            return item
+    return None
+
+
+def _is_ready(item: dict) -> bool:
+    if item.get("download_finished"):
+        return True
+    state = (item.get("download_state") or "").lower()
+    return state in ("cached", "completed", "uploading", "metaDL_done")
+
+
+def wait_until_ready(info_hash: str) -> dict | None:
+    """Poll Torbox until the torrent reports completion or the timeout is reached."""
+    deadline = time.monotonic() + TORBOX_POLL_TIMEOUT_SEC
+    last_state: str | None = None
+    while time.monotonic() < deadline:
+        item = find_by_hash(info_hash)
+        if item is None:
+            log.debug("Torrent %s not in mylist yet", info_hash)
+        else:
+            state = item.get("download_state") or ""
+            progress = item.get("progress") or 0
+            if state != last_state:
+                log.info("Torbox state: %s (progress=%.2f%%)", state, float(progress) * 100)
+                last_state = state
+            if _is_ready(item):
+                log.info("Torbox reports torrent ready: %s", info_hash)
+                return item
+        time.sleep(TORBOX_POLL_INTERVAL_SEC)
+    log.warning("Timed out waiting for Torbox to make %s available", info_hash)
+    return find_by_hash(info_hash)

--- a/torrentio.py
+++ b/torrentio.py
@@ -1,0 +1,155 @@
+import logging
+import re
+from dataclasses import dataclass
+
+import requests
+
+from config import ALLOW_4K, QUALITY_PREFERENCE, TORRENTIO_BASE_URL, TORRENTIO_OPTS
+
+log = logging.getLogger(__name__)
+
+_QUALITY_PATTERNS = {
+    "2160p": re.compile(r"\b(2160p|4k|uhd)\b", re.IGNORECASE),
+    "1080p": re.compile(r"\b1080p\b", re.IGNORECASE),
+    "720p": re.compile(r"\b720p\b", re.IGNORECASE),
+    "480p": re.compile(r"\b480p\b", re.IGNORECASE),
+}
+
+_SEEDERS_RE = re.compile(r"👤\s*(\d+)")
+_SIZE_RE = re.compile(r"💾\s*([\d.]+)\s*(GB|MB)", re.IGNORECASE)
+_SEASON_PACK_HINTS = ("season", "complete", "s%02d ", "s%02d.")
+
+
+@dataclass
+class TorrentioStream:
+    name: str
+    title: str
+    info_hash: str
+    quality: str
+    seeders: int
+    size_gb: float
+    is_season_pack: bool
+
+    @property
+    def magnet(self) -> str:
+        return f"magnet:?xt=urn:btih:{self.info_hash}"
+
+
+def _classify_quality(stream: dict) -> str:
+    blob = f"{stream.get('name', '')} {stream.get('title', '')}"
+    for label, pattern in _QUALITY_PATTERNS.items():
+        if pattern.search(blob):
+            return label
+    return "unknown"
+
+
+def _parse_seeders(title: str) -> int:
+    m = _SEEDERS_RE.search(title or "")
+    return int(m.group(1)) if m else 0
+
+
+def _parse_size_gb(title: str) -> float:
+    m = _SIZE_RE.search(title or "")
+    if not m:
+        return 0.0
+    value, unit = float(m.group(1)), m.group(2).upper()
+    return value if unit == "GB" else value / 1024.0
+
+
+def _looks_like_season_pack(title: str, season: int | None) -> bool:
+    if season is None:
+        return False
+    blob = (title or "").lower()
+    if "complete" in blob:
+        return True
+    if "season" in blob:
+        return True
+    # Match "S01" but not "S01E02"
+    if re.search(rf"s0?{season}(?!e\d)", blob, re.IGNORECASE):
+        return True
+    return False
+
+
+def _to_stream(raw: dict, season: int | None) -> TorrentioStream | None:
+    info_hash = raw.get("infoHash")
+    if not info_hash:
+        return None
+    title = raw.get("title", "") or ""
+    return TorrentioStream(
+        name=raw.get("name", "") or "",
+        title=title,
+        info_hash=info_hash.lower(),
+        quality=_classify_quality(raw),
+        seeders=_parse_seeders(title),
+        size_gb=_parse_size_gb(title),
+        is_season_pack=_looks_like_season_pack(title, season),
+    )
+
+
+def _build_url(media_type: str, imdb_id: str, season: int | None, episode: int | None) -> str:
+    prefix = f"{TORRENTIO_BASE_URL.rstrip('/')}"
+    if TORRENTIO_OPTS:
+        prefix = f"{prefix}/{TORRENTIO_OPTS.strip('/')}"
+    if media_type == "movie":
+        return f"{prefix}/stream/movie/{imdb_id}.json"
+    # series
+    if season is None or episode is None:
+        raise ValueError("season and episode are required for series")
+    return f"{prefix}/stream/series/{imdb_id}:{season}:{episode}.json"
+
+
+def fetch_streams(
+    media_type: str,
+    imdb_id: str,
+    season: int | None = None,
+    episode: int | None = None,
+    timeout: int = 30,
+) -> list[TorrentioStream]:
+    url = _build_url(media_type, imdb_id, season, episode)
+    log.info("Querying Torrentio: %s", url)
+    resp = requests.get(url, timeout=timeout)
+    resp.raise_for_status()
+    payload = resp.json() or {}
+    raw_streams = payload.get("streams", []) or []
+    parsed = [s for s in (_to_stream(r, season) for r in raw_streams) if s is not None]
+    log.info("Torrentio returned %d streams (%d parsed)", len(raw_streams), len(parsed))
+    return parsed
+
+
+def _quality_rank(stream: TorrentioStream) -> int:
+    try:
+        return QUALITY_PREFERENCE.index(stream.quality)
+    except ValueError:
+        return len(QUALITY_PREFERENCE) + 1
+
+
+def pick_best(
+    streams: list[TorrentioStream],
+    prefer_season_pack: bool = False,
+) -> TorrentioStream | None:
+    if not streams:
+        return None
+    candidates = streams if ALLOW_4K else [s for s in streams if s.quality != "2160p"]
+    if not candidates:
+        log.warning("No non-4K candidates available; falling back to full list")
+        candidates = streams
+
+    def sort_key(s: TorrentioStream):
+        return (
+            0 if prefer_season_pack and s.is_season_pack else 1,
+            _quality_rank(s),
+            -s.seeders,
+            s.size_gb,
+        )
+
+    candidates.sort(key=sort_key)
+    best = candidates[0]
+    log.info(
+        "Selected stream: quality=%s seeders=%d size=%.2fGB pack=%s hash=%s",
+        best.quality,
+        best.seeders,
+        best.size_gb,
+        best.is_season_pack,
+        best.info_hash,
+    )
+    return best

--- a/webhook_parser.py
+++ b/webhook_parser.py
@@ -1,0 +1,109 @@
+"""Parse Overseerr / Jellyseerr webhook payloads into a normalized request shape."""
+
+import logging
+import re
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+_IMDB_RE = re.compile(r"\btt\d{6,10}\b")
+
+_ACTIONABLE_TYPES = {
+    "MEDIA_APPROVED",
+    "MEDIA_AUTO_APPROVED",
+    "MEDIA_PENDING",  # only if auto-approve is off in Seerr but user still wants fulfillment
+}
+
+
+@dataclass
+class MediaRequest:
+    title: str
+    media_type: str  # "movie" or "series"
+    imdb_id: str
+    seasons: list[int] = field(default_factory=list)
+    episode: int | None = None
+
+    @property
+    def is_movie(self) -> bool:
+        return self.media_type == "movie"
+
+
+class WebhookError(ValueError):
+    pass
+
+
+class IgnoreEvent(Exception):
+    """Raised when the webhook event is informational and should not be acted on."""
+
+
+def _extract_imdb(payload: dict) -> str | None:
+    media = payload.get("media") or {}
+    for key in ("imdbId", "imdb_id", "imdb"):
+        val = media.get(key) or payload.get(key)
+        if val:
+            return str(val).strip()
+    # Custom JSON payloads may embed it in extras
+    for extra in payload.get("extra") or []:
+        name = (extra.get("name") or "").lower()
+        value = extra.get("value") or ""
+        if "imdb" in name and value:
+            return str(value).strip()
+    # Last resort: search the whole payload as a string
+    blob = str(payload)
+    m = _IMDB_RE.search(blob)
+    return m.group(0) if m else None
+
+
+def _extract_media_type(payload: dict) -> str:
+    media = payload.get("media") or {}
+    raw = (media.get("media_type") or payload.get("media_type") or "").lower()
+    if raw in ("movie", "film"):
+        return "movie"
+    if raw in ("tv", "series", "show"):
+        return "series"
+    raise WebhookError(f"Unsupported media_type: {raw!r}")
+
+
+def _extract_seasons(payload: dict) -> list[int]:
+    seasons: list[int] = []
+    for extra in payload.get("extra") or []:
+        name = (extra.get("name") or "").lower()
+        if "season" not in name:
+            continue
+        value = str(extra.get("value") or "")
+        for token in re.split(r"[,\s]+", value):
+            if token.isdigit():
+                seasons.append(int(token))
+    # Deduplicate while preserving order
+    seen: set[int] = set()
+    out: list[int] = []
+    for s in seasons:
+        if s not in seen:
+            seen.add(s)
+            out.append(s)
+    return out
+
+
+def parse(payload: dict) -> MediaRequest:
+    if not isinstance(payload, dict):
+        raise WebhookError("Webhook body must be a JSON object")
+
+    nt = payload.get("notification_type")
+    if nt == "TEST_NOTIFICATION":
+        raise IgnoreEvent("test notification")
+    if nt and nt not in _ACTIONABLE_TYPES:
+        raise IgnoreEvent(f"non-actionable notification_type={nt}")
+
+    media_type = _extract_media_type(payload)
+    imdb_id = _extract_imdb(payload)
+    if not imdb_id:
+        raise WebhookError("No IMDB id found in webhook payload")
+
+    title = payload.get("subject") or (payload.get("media") or {}).get("title") or imdb_id
+
+    seasons = _extract_seasons(payload) if media_type == "series" else []
+    if media_type == "series" and not seasons:
+        log.warning("Series request without season info; defaulting to season 1")
+        seasons = [1]
+
+    return MediaRequest(title=title, media_type=media_type, imdb_id=imdb_id, seasons=seasons)


### PR DESCRIPTION
Complete Flask webhook service that bridges Seerr request approvals to TorBox via Torrentio.

**What it does:**
- Listens on port 8088 for Seerr `MEDIA_APPROVED` webhooks
- Queries Torrentio for the best cached torrent (1080p > 720p, no 4K)
- For series: tries season pack first, falls back to per-episode
- Adds the magnet to TorBox and polls until the file is available
- Triggers a Jellyfin library refresh on success

**Deployment:** `docker compose up -d` in `/volume1/docker/jelly-stack/` on the Synology DS920+.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AR9SX5oQyrorM81mNL1dzu)_