### PR TITLE
Add EXCLUDE_REMUX filter to torrentio stream selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ WEBHOOK_SECRET=
 # Quality preferences. Lower index = preferred. 4K excluded by default.
 QUALITY_PREFERENCE=1080p,720p
 ALLOW_4K=false
+# Exclude remux/bluray rips (large files, HDD-unfriendly) unless no alternatives.
+EXCLUDE_REMUX=true
 
 # Torbox polling
 TORBOX_POLL_INTERVAL_SEC=10

--- a/config.py
+++ b/config.py
@@ -35,6 +35,7 @@ LISTEN_PORT = _env_int("LISTEN_PORT", 8088)
 # Quality preferences. 4K is excluded by default per spec (HDD constraint).
 QUALITY_PREFERENCE = [q.strip() for q in _env("QUALITY_PREFERENCE", "1080p,720p").split(",") if q.strip()]
 ALLOW_4K = _env("ALLOW_4K", "false").lower() in ("1", "true", "yes")
+EXCLUDE_REMUX = _env("EXCLUDE_REMUX", "true").lower() in ("1", "true", "yes")
 
 # How long to wait for Torbox to make the torrent available before triggering Jellyfin scan.
 TORBOX_POLL_INTERVAL_SEC = _env_int("TORBOX_POLL_INTERVAL_SEC", 10)

--- a/torrentio.py
+++ b/torrentio.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import requests
 
-from config import ALLOW_4K, QUALITY_PREFERENCE, TORRENTIO_BASE_URL, TORRENTIO_OPTS
+from config import ALLOW_4K, EXCLUDE_REMUX, QUALITY_PREFERENCE, TORRENTIO_BASE_URL, TORRENTIO_OPTS
 
 log = logging.getLogger(__name__)
 
@@ -15,6 +15,7 @@ _QUALITY_PATTERNS = {
     "480p": re.compile(r"\b480p\b", re.IGNORECASE),
 }
 
+_REMUX_RE = re.compile(r"\b(remux|bluray|blu-ray|bdremux)\b", re.IGNORECASE)
 _SEEDERS_RE = re.compile(r"👤\s*(\d+)")
 _SIZE_RE = re.compile(r"💾\s*([\d.]+)\s*(GB|MB)", re.IGNORECASE)
 _SEASON_PACK_HINTS = ("season", "complete", "s%02d ", "s%02d.")
@@ -133,6 +134,13 @@ def pick_best(
     if not candidates:
         log.warning("No non-4K candidates available; falling back to full list")
         candidates = streams
+
+    if EXCLUDE_REMUX:
+        filtered = [s for s in candidates if not _REMUX_RE.search(f"{s.name} {s.title}")]
+        if filtered:
+            candidates = filtered
+        else:
+            log.warning("Only remux/bluray candidates available; allowing them")
 
     def sort_key(s: TorrentioStream):
         return (


### PR DESCRIPTION
Adds a configurable filter that excludes remux/bluray/blu-ray/bdremux streams from selection unless no other candidates are available. Enabled by default (`EXCLUDE_REMUX=true`) to avoid large files on the Synology DS920+ HDD.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AR9SX5oQyrorM81mNL1dzu)_