### PR TITLE
Add CAM filter, WEB-DL preference, and scheduled MergeVersions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,13 @@ QUALITY_PREFERENCE=1080p,720p
 ALLOW_4K=false
 # Exclude remux/bluray rips (large files, HDD-unfriendly) unless no alternatives.
 EXCLUDE_REMUX=true
+# Exclude CAM/TS/Telesync/Screener rips (low quality) unless no alternatives.
+EXCLUDE_CAM=true
+# Prefer WEB-DL / WEBRip sources when ranking candidates.
+PREFER_WEBDL=true
+
+# Run Jellyfin MergeVersions every N hours to combine duplicate movie versions. 0 disables.
+MERGE_VERSIONS_INTERVAL_HOURS=6
 
 # Torbox polling
 TORBOX_POLL_INTERVAL_SEC=10

--- a/app.py
+++ b/app.py
@@ -1,16 +1,44 @@
 import logging
 import threading
 
+from apscheduler.schedulers.background import BackgroundScheduler
 from flask import Flask, abort, jsonify, request
 
+import jellyfin
 import processor
-from config import LISTEN_HOST, LISTEN_PORT, WEBHOOK_SECRET, configure_logging
+from config import (
+    LISTEN_HOST,
+    LISTEN_PORT,
+    MERGE_VERSIONS_INTERVAL_HOURS,
+    WEBHOOK_SECRET,
+    configure_logging,
+)
 from webhook_parser import IgnoreEvent, WebhookError, parse
 
 configure_logging()
 log = logging.getLogger("seerr-torbox")
 
 app = Flask(__name__)
+
+
+def _start_scheduler() -> BackgroundScheduler | None:
+    if MERGE_VERSIONS_INTERVAL_HOURS <= 0:
+        log.info("MergeVersions scheduler disabled (interval=%d)", MERGE_VERSIONS_INTERVAL_HOURS)
+        return None
+    scheduler = BackgroundScheduler(daemon=True)
+    scheduler.add_job(
+        jellyfin.merge_duplicate_versions,
+        trigger="interval",
+        hours=MERGE_VERSIONS_INTERVAL_HOURS,
+        id="merge_versions",
+        next_run_time=None,
+    )
+    scheduler.start()
+    log.info("Scheduled Jellyfin MergeVersions every %d hours", MERGE_VERSIONS_INTERVAL_HOURS)
+    return scheduler
+
+
+scheduler = _start_scheduler()
 
 
 def _check_auth() -> None:

--- a/config.py
+++ b/config.py
@@ -36,12 +36,17 @@ LISTEN_PORT = _env_int("LISTEN_PORT", 8088)
 QUALITY_PREFERENCE = [q.strip() for q in _env("QUALITY_PREFERENCE", "1080p,720p").split(",") if q.strip()]
 ALLOW_4K = _env("ALLOW_4K", "false").lower() in ("1", "true", "yes")
 EXCLUDE_REMUX = _env("EXCLUDE_REMUX", "true").lower() in ("1", "true", "yes")
+EXCLUDE_CAM = _env("EXCLUDE_CAM", "true").lower() in ("1", "true", "yes")
+PREFER_WEBDL = _env("PREFER_WEBDL", "true").lower() in ("1", "true", "yes")
 
 # How long to wait for Torbox to make the torrent available before triggering Jellyfin scan.
 TORBOX_POLL_INTERVAL_SEC = _env_int("TORBOX_POLL_INTERVAL_SEC", 10)
 TORBOX_POLL_TIMEOUT_SEC = _env_int("TORBOX_POLL_TIMEOUT_SEC", 600)
 
 WEBHOOK_SECRET = _env("WEBHOOK_SECRET", "")
+
+# Automatic Jellyfin merge of duplicate movie versions (every N hours; 0 disables).
+MERGE_VERSIONS_INTERVAL_HOURS = _env_int("MERGE_VERSIONS_INTERVAL_HOURS", 6)
 
 LOG_LEVEL = _env("LOG_LEVEL", "INFO").upper()
 

--- a/jellyfin.py
+++ b/jellyfin.py
@@ -22,3 +22,25 @@ def refresh_library(timeout: int = 30) -> bool:
         return False
     log.info("Jellyfin library refresh accepted (%s)", resp.status_code)
     return True
+
+
+def merge_duplicate_versions(timeout: int = 60) -> bool:
+    """Trigger Jellyfin to merge duplicate movie versions into a single entry."""
+    if not JELLYFIN_URL:
+        log.warning("JELLYFIN_URL not set; skipping MergeVersions")
+        return False
+    url = f"{JELLYFIN_URL.rstrip('/')}/Library/MergeVersions"
+    headers = {}
+    if JELLYFIN_API_KEY:
+        headers["X-Emby-Token"] = JELLYFIN_API_KEY
+    log.info("Triggering Jellyfin MergeVersions: %s", url)
+    try:
+        resp = requests.post(url, headers=headers, timeout=timeout)
+    except requests.RequestException as exc:
+        log.error("Jellyfin MergeVersions request failed: %s", exc)
+        return False
+    if resp.status_code >= 400:
+        log.error("Jellyfin MergeVersions failed: %s %s", resp.status_code, resp.text[:200])
+        return False
+    log.info("Jellyfin MergeVersions accepted (%s)", resp.status_code)
+    return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==3.0.3
 requests==2.32.3
 gunicorn==22.0.0
+APScheduler==3.10.4

--- a/torrentio.py
+++ b/torrentio.py
@@ -4,7 +4,15 @@ from dataclasses import dataclass
 
 import requests
 
-from config import ALLOW_4K, EXCLUDE_REMUX, QUALITY_PREFERENCE, TORRENTIO_BASE_URL, TORRENTIO_OPTS
+from config import (
+    ALLOW_4K,
+    EXCLUDE_CAM,
+    EXCLUDE_REMUX,
+    PREFER_WEBDL,
+    QUALITY_PREFERENCE,
+    TORRENTIO_BASE_URL,
+    TORRENTIO_OPTS,
+)
 
 log = logging.getLogger(__name__)
 
@@ -16,6 +24,8 @@ _QUALITY_PATTERNS = {
 }
 
 _REMUX_RE = re.compile(r"\b(remux|bluray|blu-ray|bdremux)\b", re.IGNORECASE)
+_CAM_RE = re.compile(r"\b(cam|camrip|hdcam|ts|telesync|hdts|scr|screener|dvdscr|workprint|r5)\b", re.IGNORECASE)
+_WEBDL_RE = re.compile(r"\b(web-?dl|webrip|web)\b", re.IGNORECASE)
 _SEEDERS_RE = re.compile(r"👤\s*(\d+)")
 _SIZE_RE = re.compile(r"💾\s*([\d.]+)\s*(GB|MB)", re.IGNORECASE)
 _SEASON_PACK_HINTS = ("season", "complete", "s%02d ", "s%02d.")
@@ -142,10 +152,19 @@ def pick_best(
         else:
             log.warning("Only remux/bluray candidates available; allowing them")
 
+    if EXCLUDE_CAM:
+        filtered = [s for s in candidates if not _CAM_RE.search(f"{s.name} {s.title}")]
+        if filtered:
+            candidates = filtered
+        else:
+            log.warning("Only cam/telesync candidates available; allowing them")
+
     def sort_key(s: TorrentioStream):
+        is_webdl = bool(_WEBDL_RE.search(f"{s.name} {s.title}"))
         return (
             0 if prefer_season_pack and s.is_season_pack else 1,
             _quality_rank(s),
+            0 if PREFER_WEBDL and is_webdl else 1,
             -s.seeders,
             s.size_gb,
         )


### PR DESCRIPTION
## Summary
- Adds `EXCLUDE_CAM` filter for `cam/camrip/ts/telesync/scr/screener/hdts/hdcam/dvdscr/workprint/r5`
- Adds `PREFER_WEBDL` to bias selection toward WEB-DL / WEBRip sources
- Adds APScheduler background job calling Jellyfin `/Library/MergeVersions` every `MERGE_VERSIONS_INTERVAL_HOURS` (default 6h)
- Adds `APScheduler==3.10.4` to requirements
- New env vars documented in `.env.example`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AR9SX5oQyrorM81mNL1dzu)_