### PR TITLE
Fix IMDB lookup via Seerr API + quality/filter/retry improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,13 +2,20 @@
 TORBOX_API_KEY=replace-me
 TORBOX_BASE_URL=https://api.torbox.app/v1/api
 
-# Torrentio. Optional opts segment (e.g. providers, sort) appended to base URL.
+# Torrentio. Append provider/sort options to the base URL via TORRENTIO_OPTS.
+# Example: providers=yts,eztv,rarbg,1337x,thepiratebay&sort=qualitysize&language=english
 TORRENTIO_BASE_URL=https://torrentio.strem.fun
 TORRENTIO_OPTS=
 
 # Jellyfin
 JELLYFIN_URL=http://10.0.0.10:8096
 JELLYFIN_API_KEY=
+# Seconds to wait after TorBox reports ready before triggering library scan (TMC strm sync delay).
+JELLYFIN_REFRESH_DELAY_SEC=60
+
+# Seerr (Jellyseerr / Overseerr) — used to look up IMDB ID when not present in the webhook.
+SEERR_URL=http://10.0.0.10:5055
+SEERR_API_KEY=replace-me
 
 # Listener
 LISTEN_HOST=0.0.0.0
@@ -18,21 +25,27 @@ LISTEN_PORT=8088
 # or use the query param ?secret=<value>.
 WEBHOOK_SECRET=
 
-# Quality preferences. Lower index = preferred. 4K excluded by default.
-QUALITY_PREFERENCE=1080p,720p
-ALLOW_4K=false
-# Exclude remux/bluray rips (large files, HDD-unfriendly) unless no alternatives.
+# Quality preferences — lower index = more preferred. 4K allowed, 1080p tried first.
+QUALITY_PREFERENCE=1080p,2160p,720p
+ALLOW_4K=true
+# Exclude remux/bluray rips (very large, HDD-unfriendly) unless no alternatives.
 EXCLUDE_REMUX=true
 # Exclude CAM/TS/Telesync/Screener rips (low quality) unless no alternatives.
 EXCLUDE_CAM=true
-# Prefer WEB-DL / WEBRip sources when ranking candidates.
+# Prefer WEB-DL / WEBRip sources over encode-only releases.
 PREFER_WEBDL=true
-
-# Run Jellyfin MergeVersions every N hours to combine duplicate movie versions. 0 disables.
-MERGE_VERSIONS_INTERVAL_HOURS=6
+# Prefer HEVC/x265 encodes (~40% smaller than H.264 at same quality).
+PREFER_HEVC=true
+# Minimum seeder count to include a candidate (0 = no filter; unparseable seeders always pass).
+MIN_SEEDERS=3
+# Maximum file size in GB (0 = no limit; unparseable size always passes).
+MAX_SIZE_GB=0
 
 # Torbox polling
 TORBOX_POLL_INTERVAL_SEC=10
 TORBOX_POLL_TIMEOUT_SEC=600
+
+# Run Jellyfin MergeVersions every N hours to combine duplicate movie versions. 0 disables.
+MERGE_VERSIONS_INTERVAL_HOURS=6
 
 LOG_LEVEL=INFO

--- a/config.py
+++ b/config.py
@@ -23,21 +23,30 @@ TORBOX_API_KEY = _env("TORBOX_API_KEY", required=True)
 TORBOX_BASE_URL = _env("TORBOX_BASE_URL", "https://api.torbox.app/v1/api")
 
 TORRENTIO_BASE_URL = _env("TORRENTIO_BASE_URL", "https://torrentio.strem.fun")
-# Torrentio config string controls trackers/providers; the default is the public defaults.
 TORRENTIO_OPTS = _env("TORRENTIO_OPTS", "")
 
 JELLYFIN_URL = _env("JELLYFIN_URL", "http://10.0.0.10:8096")
 JELLYFIN_API_KEY = _env("JELLYFIN_API_KEY", "")
+# Seconds to wait after TorBox reports ready before triggering Jellyfin scan.
+JELLYFIN_REFRESH_DELAY_SEC = _env_int("JELLYFIN_REFRESH_DELAY_SEC", 60)
+
+SEERR_URL = _env("SEERR_URL", "http://10.0.0.10:5055")
+SEERR_API_KEY = _env("SEERR_API_KEY", "")
 
 LISTEN_HOST = _env("LISTEN_HOST", "0.0.0.0")
 LISTEN_PORT = _env_int("LISTEN_PORT", 8088)
 
-# Quality preferences. 4K is excluded by default per spec (HDD constraint).
-QUALITY_PREFERENCE = [q.strip() for q in _env("QUALITY_PREFERENCE", "1080p,720p").split(",") if q.strip()]
-ALLOW_4K = _env("ALLOW_4K", "false").lower() in ("1", "true", "yes")
+# Quality preferences — 1080p first, 4K fallback, 720p last resort.
+QUALITY_PREFERENCE = [q.strip() for q in _env("QUALITY_PREFERENCE", "1080p,2160p,720p").split(",") if q.strip()]
+ALLOW_4K = _env("ALLOW_4K", "true").lower() in ("1", "true", "yes")
 EXCLUDE_REMUX = _env("EXCLUDE_REMUX", "true").lower() in ("1", "true", "yes")
 EXCLUDE_CAM = _env("EXCLUDE_CAM", "true").lower() in ("1", "true", "yes")
 PREFER_WEBDL = _env("PREFER_WEBDL", "true").lower() in ("1", "true", "yes")
+PREFER_HEVC = _env("PREFER_HEVC", "true").lower() in ("1", "true", "yes")
+# Minimum seeders to include a candidate (0 = no filter; unknown seeders always pass).
+MIN_SEEDERS = _env_int("MIN_SEEDERS", 3)
+# Maximum file size in GB to include a candidate (0 = no limit; unknown size always passes).
+MAX_SIZE_GB = _env_int("MAX_SIZE_GB", 0)
 
 # How long to wait for Torbox to make the torrent available before triggering Jellyfin scan.
 TORBOX_POLL_INTERVAL_SEC = _env_int("TORBOX_POLL_INTERVAL_SEC", 10)

--- a/processor.py
+++ b/processor.py
@@ -1,52 +1,72 @@
 import logging
+import time
 
 import jellyfin
 import torbox
 import torrentio
+from config import JELLYFIN_REFRESH_DELAY_SEC
 from webhook_parser import MediaRequest
 
 log = logging.getLogger(__name__)
 
 
+def _add_best_from(candidates: list, label: str) -> bool:
+    """Try each ranked candidate in order; return True on first success."""
+    for stream in candidates:
+        try:
+            torbox.add_magnet(stream.magnet)
+            torbox.wait_until_ready(stream.info_hash)
+            return True
+        except Exception as exc:
+            log.warning(
+                "Failed to add %s (hash=%s quality=%s): %s — trying next candidate",
+                label, stream.info_hash, stream.quality, exc,
+            )
+    log.error("All %d candidate(s) failed for %s", len(candidates), label)
+    return False
+
+
 def _process_movie(req: MediaRequest) -> bool:
     streams = torrentio.fetch_streams("movie", req.imdb_id)
-    best = torrentio.pick_best(streams)
-    if not best:
+    candidates = torrentio.rank_streams(streams)
+    if not candidates:
         log.error("No suitable stream for movie %s (%s)", req.title, req.imdb_id)
         return False
-    torbox.add_magnet(best.magnet)
-    torbox.wait_until_ready(best.info_hash)
-    return True
+    log.info("Trying %d candidate(s) for %s", len(candidates), req.title)
+    return _add_best_from(candidates, req.title)
 
 
 def _process_season(req: MediaRequest, season: int) -> bool:
-    # First episode lookup to discover season packs.
     streams = torrentio.fetch_streams("series", req.imdb_id, season=season, episode=1)
-    season_pack = torrentio.pick_best(streams, prefer_season_pack=True)
-    if season_pack and season_pack.is_season_pack:
-        log.info("Using season pack for %s S%02d", req.title, season)
-        torbox.add_magnet(season_pack.magnet)
-        torbox.wait_until_ready(season_pack.info_hash)
-        return True
+    pack_candidates = torrentio.rank_streams(streams, prefer_season_pack=True)
 
-    log.info("No season pack for %s S%02d; falling back to per-episode", req.title, season)
+    if pack_candidates and pack_candidates[0].is_season_pack:
+        log.info("Trying season pack(s) for %s S%02d", req.title, season)
+        if _add_best_from(
+            [s for s in pack_candidates if s.is_season_pack],
+            f"{req.title} S{season:02d} pack",
+        ):
+            return True
+        log.info("Season pack(s) failed; falling back to per-episode")
+
+    log.info("No season pack for %s S%02d; going per-episode", req.title, season)
     added = 0
     episode = 1
-    # Walk episodes until Torrentio returns nothing.
     while True:
         ep_streams = (
-            streams if episode == 1 else torrentio.fetch_streams("series", req.imdb_id, season=season, episode=episode)
+            streams
+            if episode == 1
+            else torrentio.fetch_streams("series", req.imdb_id, season=season, episode=episode)
         )
         if not ep_streams:
             log.info("No more episodes returned at S%02dE%02d", season, episode)
             break
-        best = torrentio.pick_best(ep_streams)
-        if best:
-            torbox.add_magnet(best.magnet)
-            torbox.wait_until_ready(best.info_hash)
-            added += 1
+        ep_candidates = torrentio.rank_streams(ep_streams)
+        if ep_candidates:
+            if _add_best_from(ep_candidates, f"{req.title} S{season:02d}E{episode:02d}"):
+                added += 1
         episode += 1
-        if episode > 50:  # safety cap
+        if episode > 50:
             log.warning("Episode cap (50) reached for %s S%02d", req.title, season)
             break
     return added > 0
@@ -64,6 +84,9 @@ def process(req: MediaRequest) -> bool:
                     success = True
     finally:
         if success:
+            if JELLYFIN_REFRESH_DELAY_SEC > 0:
+                log.info("Waiting %ds before triggering Jellyfin refresh", JELLYFIN_REFRESH_DELAY_SEC)
+                time.sleep(JELLYFIN_REFRESH_DELAY_SEC)
             jellyfin.refresh_library()
         else:
             log.warning("No content added; skipping Jellyfin refresh for %s", req.title)

--- a/seerr.py
+++ b/seerr.py
@@ -1,0 +1,21 @@
+import logging
+
+import requests
+
+from config import SEERR_API_KEY, SEERR_URL
+
+log = logging.getLogger(__name__)
+
+
+def _headers() -> dict[str, str]:
+    return {"X-Api-Key": SEERR_API_KEY} if SEERR_API_KEY else {}
+
+
+def get_request(request_id: str | int, timeout: int = 10) -> dict:
+    if not SEERR_URL:
+        raise RuntimeError("SEERR_URL is not configured")
+    url = f"{SEERR_URL.rstrip('/')}/api/v1/request/{request_id}"
+    log.info("Fetching Seerr request: %s", url)
+    resp = requests.get(url, headers=_headers(), timeout=timeout)
+    resp.raise_for_status()
+    return resp.json() or {}

--- a/torrentio.py
+++ b/torrentio.py
@@ -8,6 +8,9 @@ from config import (
     ALLOW_4K,
     EXCLUDE_CAM,
     EXCLUDE_REMUX,
+    MAX_SIZE_GB,
+    MIN_SEEDERS,
+    PREFER_HEVC,
     PREFER_WEBDL,
     QUALITY_PREFERENCE,
     TORRENTIO_BASE_URL,
@@ -26,9 +29,9 @@ _QUALITY_PATTERNS = {
 _REMUX_RE = re.compile(r"\b(remux|bluray|blu-ray|bdremux)\b", re.IGNORECASE)
 _CAM_RE = re.compile(r"\b(cam|camrip|hdcam|ts|telesync|hdts|scr|screener|dvdscr|workprint|r5)\b", re.IGNORECASE)
 _WEBDL_RE = re.compile(r"\b(web-?dl|webrip|web)\b", re.IGNORECASE)
+_HEVC_RE = re.compile(r"\b(hevc|x265|h\.?265)\b", re.IGNORECASE)
 _SEEDERS_RE = re.compile(r"👤\s*(\d+)")
 _SIZE_RE = re.compile(r"💾\s*([\d.]+)\s*(GB|MB)", re.IGNORECASE)
-_SEASON_PACK_HINTS = ("season", "complete", "s%02d ", "s%02d.")
 
 
 @dataclass
@@ -75,7 +78,6 @@ def _looks_like_season_pack(title: str, season: int | None) -> bool:
         return True
     if "season" in blob:
         return True
-    # Match "S01" but not "S01E02"
     if re.search(rf"s0?{season}(?!e\d)", blob, re.IGNORECASE):
         return True
     return False
@@ -103,7 +105,6 @@ def _build_url(media_type: str, imdb_id: str, season: int | None, episode: int |
         prefix = f"{prefix}/{TORRENTIO_OPTS.strip('/')}"
     if media_type == "movie":
         return f"{prefix}/stream/movie/{imdb_id}.json"
-    # series
     if season is None or episode is None:
         raise ValueError("season and episode are required for series")
     return f"{prefix}/stream/series/{imdb_id}:{season}:{episode}.json"
@@ -134,16 +135,18 @@ def _quality_rank(stream: TorrentioStream) -> int:
         return len(QUALITY_PREFERENCE) + 1
 
 
-def pick_best(
+def rank_streams(
     streams: list[TorrentioStream],
     prefer_season_pack: bool = False,
-) -> TorrentioStream | None:
+) -> list[TorrentioStream]:
+    """Return streams sorted by preference, applying content/quality filters with fallbacks."""
     if not streams:
-        return None
+        return []
+
     candidates = streams if ALLOW_4K else [s for s in streams if s.quality != "2160p"]
     if not candidates:
-        log.warning("No non-4K candidates available; falling back to full list")
-        candidates = streams
+        log.warning("No non-4K candidates; falling back to full list")
+        candidates = list(streams)
 
     if EXCLUDE_REMUX:
         filtered = [s for s in candidates if not _REMUX_RE.search(f"{s.name} {s.title}")]
@@ -159,18 +162,45 @@ def pick_best(
         else:
             log.warning("Only cam/telesync candidates available; allowing them")
 
-    def sort_key(s: TorrentioStream):
-        is_webdl = bool(_WEBDL_RE.search(f"{s.name} {s.title}"))
+    if MIN_SEEDERS > 0:
+        # seeders==0 means unparseable (no 👤 in title), give benefit of the doubt
+        filtered = [s for s in candidates if s.seeders == 0 or s.seeders >= MIN_SEEDERS]
+        if filtered:
+            candidates = filtered
+        else:
+            log.warning("No candidates meet MIN_SEEDERS=%d; allowing all", MIN_SEEDERS)
+
+    if MAX_SIZE_GB > 0:
+        # size_gb==0.0 means unparseable, don't exclude
+        filtered = [s for s in candidates if s.size_gb == 0.0 or s.size_gb <= MAX_SIZE_GB]
+        if filtered:
+            candidates = filtered
+        else:
+            log.warning("No candidates within MAX_SIZE_GB=%d; allowing all", MAX_SIZE_GB)
+
+    def sort_key(s: TorrentioStream) -> tuple:
+        blob = f"{s.name} {s.title}"
         return (
             0 if prefer_season_pack and s.is_season_pack else 1,
             _quality_rank(s),
-            0 if PREFER_WEBDL and is_webdl else 1,
+            0 if PREFER_WEBDL and _WEBDL_RE.search(blob) else 1,
+            0 if PREFER_HEVC and _HEVC_RE.search(blob) else 1,
             -s.seeders,
             s.size_gb,
         )
 
     candidates.sort(key=sort_key)
-    best = candidates[0]
+    return candidates
+
+
+def pick_best(
+    streams: list[TorrentioStream],
+    prefer_season_pack: bool = False,
+) -> TorrentioStream | None:
+    ranked = rank_streams(streams, prefer_season_pack=prefer_season_pack)
+    if not ranked:
+        return None
+    best = ranked[0]
     log.info(
         "Selected stream: quality=%s seeders=%d size=%.2fGB pack=%s hash=%s",
         best.quality,

--- a/webhook_parser.py
+++ b/webhook_parser.py
@@ -4,6 +4,8 @@ import logging
 import re
 from dataclasses import dataclass, field
 
+import seerr
+
 log = logging.getLogger(__name__)
 
 _IMDB_RE = re.compile(r"\btt\d{6,10}\b")
@@ -11,7 +13,7 @@ _IMDB_RE = re.compile(r"\btt\d{6,10}\b")
 _ACTIONABLE_TYPES = {
     "MEDIA_APPROVED",
     "MEDIA_AUTO_APPROVED",
-    "MEDIA_PENDING",  # only if auto-approve is off in Seerr but user still wants fulfillment
+    "MEDIA_PENDING",
 }
 
 
@@ -42,21 +44,51 @@ def _extract_imdb(payload: dict) -> str | None:
         val = media.get(key) or payload.get(key)
         if val:
             return str(val).strip()
-    # Custom JSON payloads may embed it in extras
     for extra in payload.get("extra") or []:
         name = (extra.get("name") or "").lower()
         value = extra.get("value") or ""
         if "imdb" in name and value:
             return str(value).strip()
-    # Last resort: search the whole payload as a string
     blob = str(payload)
     m = _IMDB_RE.search(blob)
     return m.group(0) if m else None
 
 
+def _extract_request_id(payload: dict) -> str | None:
+    req = payload.get("request") or {}
+    rid = req.get("request_id") or req.get("id") or payload.get("request_id")
+    return str(rid) if rid else None
+
+
+def _fetch_from_seerr(payload: dict) -> tuple[str | None, list[int]]:
+    """Return (imdb_id, seasons) from the Seerr API using the request_id in the payload."""
+    request_id = _extract_request_id(payload)
+    if not request_id:
+        return None, []
+    try:
+        data = seerr.get_request(request_id)
+    except Exception as exc:
+        log.warning("Seerr API lookup failed for request %s: %s", request_id, exc)
+        return None, []
+
+    media = data.get("media") or {}
+    imdb_id = media.get("imdbId") or media.get("imdb_id") or None
+    if imdb_id:
+        imdb_id = str(imdb_id).strip()
+        log.info("Got IMDB ID from Seerr API: %s (request=%s)", imdb_id, request_id)
+
+    seasons: list[int] = []
+    for s in data.get("seasons") or []:
+        num = s.get("seasonNumber")
+        if isinstance(num, int) and num > 0:
+            seasons.append(num)
+
+    return imdb_id or None, seasons
+
+
 def _extract_media_type(payload: dict) -> str:
     media = payload.get("media") or {}
-    raw = (media.get("media_type") or payload.get("media_type") or "").lower()
+    raw = (media.get("media_type") or media.get("mediaType") or payload.get("media_type") or "").lower()
     if raw in ("movie", "film"):
         return "movie"
     if raw in ("tv", "series", "show"):
@@ -74,7 +106,6 @@ def _extract_seasons(payload: dict) -> list[int]:
         for token in re.split(r"[,\s]+", value):
             if token.isdigit():
                 seasons.append(int(token))
-    # Deduplicate while preserving order
     seen: set[int] = set()
     out: list[int] = []
     for s in seasons:
@@ -95,15 +126,24 @@ def parse(payload: dict) -> MediaRequest:
         raise IgnoreEvent(f"non-actionable notification_type={nt}")
 
     media_type = _extract_media_type(payload)
+
     imdb_id = _extract_imdb(payload)
+    seerr_seasons: list[int] = []
     if not imdb_id:
-        raise WebhookError("No IMDB id found in webhook payload")
+        log.info("IMDB ID not in payload; querying Seerr API")
+        imdb_id, seerr_seasons = _fetch_from_seerr(payload)
+
+    if not imdb_id:
+        raise WebhookError("No IMDB id found in webhook payload or Seerr API")
 
     title = payload.get("subject") or (payload.get("media") or {}).get("title") or imdb_id
 
-    seasons = _extract_seasons(payload) if media_type == "series" else []
-    if media_type == "series" and not seasons:
-        log.warning("Series request without season info; defaulting to season 1")
-        seasons = [1]
+    if media_type == "series":
+        seasons = _extract_seasons(payload) or seerr_seasons
+        if not seasons:
+            log.warning("Series request without season info; defaulting to season 1")
+            seasons = [1]
+    else:
+        seasons = []
 
     return MediaRequest(title=title, media_type=media_type, imdb_id=imdb_id, seasons=seasons)


### PR DESCRIPTION
## Summary
- **Bug fix:** webhook payload for `MEDIA_AUTO_APPROVED` often omits the IMDB ID. Now falls back to `GET /api/v1/request/{id}` on the Seerr API to retrieve it; also extracts season list from the API response for series
- **New module:** `seerr.py` — lightweight Seerr API client
- **Config additions:** `SEERR_URL`, `SEERR_API_KEY`, `PREFER_HEVC`, `MIN_SEEDERS`, `MAX_SIZE_GB`, `JELLYFIN_REFRESH_DELAY_SEC`
- **Default changes:** `ALLOW_4K=true`, `QUALITY_PREFERENCE=1080p,2160p,720p`
- **torrentio:** `rank_streams()` returns full sorted+filtered list; MIN_SEEDERS and MAX_SIZE_GB filters with graceful fallback; HEVC/x265 preference in sort
- **processor:** retries with next ranked candidate on TorBox failure; waits `JELLYFIN_REFRESH_DELAY_SEC` (60s) before Jellyfin scan to let TMC `.strm` files sync

---
_Generated by [Claude Code](https://claude.ai/code/session_01AR9SX5oQyrorM81mNL1dzu)_