### PR TITLE
Add Zilean as primary scraper with Torrentio fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,11 @@
 TORBOX_API_KEY=replace-me
 TORBOX_BASE_URL=https://api.torbox.app/v1/api
 
-# Torrentio. Append provider/sort options to the base URL via TORRENTIO_OPTS.
+# Zilean — local torrent scraper, tried first before Torrentio.
+ZILEAN_URL=http://10.0.0.10:8181
+ZILEAN_ENABLED=true
+
+# Torrentio — public fallback scraper. Append provider/sort options via TORRENTIO_OPTS.
 # Example: providers=yts,eztv,rarbg,1337x,thepiratebay&sort=qualitysize&language=english
 TORRENTIO_BASE_URL=https://torrentio.strem.fun
 TORRENTIO_OPTS=

--- a/config.py
+++ b/config.py
@@ -22,6 +22,9 @@ def _env_int(name: str, default: int) -> int:
 TORBOX_API_KEY = _env("TORBOX_API_KEY", required=True)
 TORBOX_BASE_URL = _env("TORBOX_BASE_URL", "https://api.torbox.app/v1/api")
 
+ZILEAN_URL = _env("ZILEAN_URL", "http://10.0.0.10:8181")
+ZILEAN_ENABLED = _env("ZILEAN_ENABLED", "true").lower() in ("1", "true", "yes")
+
 TORRENTIO_BASE_URL = _env("TORRENTIO_BASE_URL", "https://torrentio.strem.fun")
 TORRENTIO_OPTS = _env("TORRENTIO_OPTS", "")
 

--- a/processor.py
+++ b/processor.py
@@ -4,10 +4,39 @@ import time
 import jellyfin
 import torbox
 import torrentio
-from config import JELLYFIN_REFRESH_DELAY_SEC
+import zilean
+from config import JELLYFIN_REFRESH_DELAY_SEC, ZILEAN_ENABLED
 from webhook_parser import MediaRequest
 
 log = logging.getLogger(__name__)
+
+
+def _rank(streams, prefer_season_pack: bool = False):
+    return torrentio.rank_streams(streams, prefer_season_pack=prefer_season_pack)
+
+
+def _fetch_movie_candidates(req: MediaRequest) -> list:
+    if ZILEAN_ENABLED:
+        streams = zilean.fetch_streams(req.title)
+        candidates = _rank(streams)
+        if candidates:
+            log.info("Zilean found %d candidate(s) for movie %s", len(candidates), req.title)
+            return candidates
+        log.info("Zilean: no candidates for %s; falling back to Torrentio", req.title)
+    streams = torrentio.fetch_streams("movie", req.imdb_id)
+    return _rank(streams)
+
+
+def _fetch_season_candidates(req: MediaRequest, season: int, episode: int, prefer_season_pack: bool = False) -> list:
+    if ZILEAN_ENABLED:
+        streams = zilean.fetch_streams(req.title, season=season, episode=episode)
+        candidates = _rank(streams, prefer_season_pack=prefer_season_pack)
+        if candidates:
+            log.info("Zilean found %d candidate(s) for %s S%02dE%02d", len(candidates), req.title, season, episode)
+            return candidates
+        log.info("Zilean: no candidates for %s S%02dE%02d; falling back to Torrentio", req.title, season, episode)
+    streams = torrentio.fetch_streams("series", req.imdb_id, season=season, episode=episode)
+    return _rank(streams, prefer_season_pack=prefer_season_pack)
 
 
 def _add_best_from(candidates: list, label: str) -> bool:
@@ -27,8 +56,7 @@ def _add_best_from(candidates: list, label: str) -> bool:
 
 
 def _process_movie(req: MediaRequest) -> bool:
-    streams = torrentio.fetch_streams("movie", req.imdb_id)
-    candidates = torrentio.rank_streams(streams)
+    candidates = _fetch_movie_candidates(req)
     if not candidates:
         log.error("No suitable stream for movie %s (%s)", req.title, req.imdb_id)
         return False
@@ -37,34 +65,28 @@ def _process_movie(req: MediaRequest) -> bool:
 
 
 def _process_season(req: MediaRequest, season: int) -> bool:
-    streams = torrentio.fetch_streams("series", req.imdb_id, season=season, episode=1)
-    pack_candidates = torrentio.rank_streams(streams, prefer_season_pack=True)
+    pack_candidates = _fetch_season_candidates(req, season, episode=1, prefer_season_pack=True)
 
     if pack_candidates and pack_candidates[0].is_season_pack:
         log.info("Trying season pack(s) for %s S%02d", req.title, season)
-        if _add_best_from(
-            [s for s in pack_candidates if s.is_season_pack],
-            f"{req.title} S{season:02d} pack",
-        ):
+        packs = [s for s in pack_candidates if s.is_season_pack]
+        if _add_best_from(packs, f"{req.title} S{season:02d} pack"):
             return True
         log.info("Season pack(s) failed; falling back to per-episode")
 
-    log.info("No season pack for %s S%02d; going per-episode", req.title, season)
+    log.info("Going per-episode for %s S%02d", req.title, season)
     added = 0
     episode = 1
     while True:
-        ep_streams = (
-            streams
-            if episode == 1
-            else torrentio.fetch_streams("series", req.imdb_id, season=season, episode=episode)
-        )
-        if not ep_streams:
+        if episode == 1:
+            candidates = [s for s in pack_candidates if not s.is_season_pack] or pack_candidates
+        else:
+            candidates = _fetch_season_candidates(req, season, episode=episode)
+        if not candidates:
             log.info("No more episodes returned at S%02dE%02d", season, episode)
             break
-        ep_candidates = torrentio.rank_streams(ep_streams)
-        if ep_candidates:
-            if _add_best_from(ep_candidates, f"{req.title} S{season:02d}E{episode:02d}"):
-                added += 1
+        if _add_best_from(candidates, f"{req.title} S{season:02d}E{episode:02d}"):
+            added += 1
         episode += 1
         if episode > 50:
             log.warning("Episode cap (50) reached for %s S%02d", req.title, season)

--- a/zilean.py
+++ b/zilean.py
@@ -1,0 +1,54 @@
+import logging
+
+import requests
+
+from config import ZILEAN_URL
+from torrentio import TorrentioStream, _classify_quality, _looks_like_season_pack
+
+log = logging.getLogger(__name__)
+
+_BYTES_PER_GB = 1024 ** 3
+
+
+def _to_stream(raw: dict, season: int | None) -> TorrentioStream | None:
+    info_hash = raw.get("infoHash")
+    if not info_hash:
+        return None
+    title = raw.get("title", "") or ""
+    size_bytes = raw.get("size") or 0
+    size_gb = round(size_bytes / _BYTES_PER_GB, 2) if size_bytes else 0.0
+    blob = {"name": title, "title": title}
+    return TorrentioStream(
+        name="Zilean",
+        title=title,
+        info_hash=info_hash.lower(),
+        quality=_classify_quality(blob),
+        seeders=0,  # Zilean doesn't expose seeder counts
+        size_gb=size_gb,
+        is_season_pack=_looks_like_season_pack(title, season),
+    )
+
+
+def fetch_streams(
+    query: str,
+    season: int | None = None,
+    episode: int | None = None,
+    timeout: int = 10,
+) -> list[TorrentioStream]:
+    params: dict[str, object] = {"Query": query}
+    if season is not None:
+        params["Season"] = season
+    if episode is not None:
+        params["Episode"] = episode
+    url = f"{ZILEAN_URL.rstrip('/')}/torrents/search"
+    log.info("Querying Zilean: %s params=%s", url, params)
+    try:
+        resp = requests.get(url, params=params, timeout=timeout)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        log.warning("Zilean unavailable: %s", exc)
+        return []
+    raw_list = resp.json() or []
+    parsed = [s for s in (_to_stream(r, season) for r in raw_list) if s is not None]
+    log.info("Zilean returned %d results (%d parsed)", len(raw_list), len(parsed))
+    return parsed


### PR DESCRIPTION
Zilean (local, `http://10.0.0.10:8181`) is now tried first for every lookup. Torrentio is only called when Zilean returns no usable candidates after filtering. All existing filters (EXCLUDE_REMUX, EXCLUDE_CAM, ALLOW_4K, MIN_SEEDERS, etc.) apply to both sources via the shared `rank_streams()` logic.

New env vars: `ZILEAN_URL`, `ZILEAN_ENABLED`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AR9SX5oQyrorM81mNL1dzu)_