### PR TITLE
Add startup catch-up task for missed approved requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,4 +52,9 @@ TORBOX_POLL_TIMEOUT_SEC=600
 # Run Jellyfin MergeVersions every N hours to combine duplicate movie versions. 0 disables.
 MERGE_VERSIONS_INTERVAL_HOURS=6
 
+# On-startup catch-up: re-process approved Seerr requests not yet in TorBox.
+CATCHUP_ENABLED=true
+CATCHUP_DELAY_SEC=30
+CATCHUP_TAKE=20
+
 LOG_LEVEL=INFO

--- a/app.py
+++ b/app.py
@@ -4,9 +4,11 @@ import threading
 from apscheduler.schedulers.background import BackgroundScheduler
 from flask import Flask, abort, jsonify, request
 
+import catchup
 import jellyfin
 import processor
 from config import (
+    CATCHUP_ENABLED,
     LISTEN_HOST,
     LISTEN_PORT,
     MERGE_VERSIONS_INTERVAL_HOURS,
@@ -39,6 +41,9 @@ def _start_scheduler() -> BackgroundScheduler | None:
 
 
 scheduler = _start_scheduler()
+
+if CATCHUP_ENABLED:
+    catchup.schedule()
 
 
 def _check_auth() -> None:

--- a/catchup.py
+++ b/catchup.py
@@ -1,0 +1,91 @@
+"""On-startup catch-up: process approved Seerr requests that arrived while the service was down."""
+
+import logging
+import threading
+import time
+
+import processor
+import seerr
+import torbox
+from config import CATCHUP_DELAY_SEC, CATCHUP_TAKE
+from webhook_parser import MediaRequest
+
+log = logging.getLogger(__name__)
+
+
+def _build_request(item: dict) -> MediaRequest | None:
+    media = item.get("media") or {}
+    raw_type = (media.get("mediaType") or media.get("media_type") or "").lower()
+    if raw_type == "movie":
+        media_type = "movie"
+    elif raw_type in ("tv", "series"):
+        media_type = "series"
+    else:
+        log.debug("Catch-up: skipping request %s — unknown media type %r", item.get("id"), raw_type)
+        return None
+
+    imdb_id = media.get("imdbId") or media.get("imdb_id")
+    if not imdb_id:
+        log.debug("Catch-up: skipping request %s — no IMDB ID", item.get("id"))
+        return None
+
+    title = media.get("title") or str(imdb_id)
+
+    seasons: list[int] = []
+    if media_type == "series":
+        for s in item.get("seasons") or []:
+            num = s.get("seasonNumber")
+            if isinstance(num, int) and num > 0:
+                seasons.append(num)
+        if not seasons:
+            seasons = [1]
+
+    return MediaRequest(title=title, media_type=media_type, imdb_id=imdb_id, seasons=seasons)
+
+
+def run() -> None:
+    log.info("Catch-up: fetching up to %d approved requests from Seerr", CATCHUP_TAKE)
+    try:
+        items = seerr.list_approved_requests(take=CATCHUP_TAKE)
+    except Exception as exc:
+        log.error("Catch-up: failed to fetch Seerr requests: %s", exc)
+        return
+
+    log.info("Catch-up: %d approved request(s) to check", len(items))
+
+    try:
+        torbox_list = torbox.list_torrents()
+    except Exception as exc:
+        log.error("Catch-up: failed to fetch TorBox list: %s", exc)
+        torbox_list = []
+
+    torbox_names = {(item.get("name") or "").lower() for item in torbox_list}
+
+    def _in_torbox(title: str) -> bool:
+        needle = title.lower()
+        return any(needle in name or name in needle for name in torbox_names)
+
+    for item in items:
+        req = _build_request(item)
+        if req is None:
+            continue
+        if _in_torbox(req.title):
+            log.info("Catch-up: '%s' already in TorBox — skipping", req.title)
+            continue
+        log.info("Catch-up: processing missed request '%s' (%s)", req.title, req.imdb_id)
+        try:
+            processor.process(req)
+        except Exception as exc:
+            log.error("Catch-up: error processing '%s': %s", req.title, exc)
+
+    log.info("Catch-up complete")
+
+
+def schedule() -> None:
+    def _delayed():
+        log.info("Catch-up: waiting %ds before starting", CATCHUP_DELAY_SEC)
+        time.sleep(CATCHUP_DELAY_SEC)
+        run()
+
+    thread = threading.Thread(target=_delayed, name="catchup", daemon=True)
+    thread.start()

--- a/config.py
+++ b/config.py
@@ -57,6 +57,10 @@ TORBOX_POLL_TIMEOUT_SEC = _env_int("TORBOX_POLL_TIMEOUT_SEC", 600)
 
 WEBHOOK_SECRET = _env("WEBHOOK_SECRET", "")
 
+CATCHUP_ENABLED = _env("CATCHUP_ENABLED", "true").lower() in ("1", "true", "yes")
+CATCHUP_DELAY_SEC = _env_int("CATCHUP_DELAY_SEC", 30)
+CATCHUP_TAKE = _env_int("CATCHUP_TAKE", 20)
+
 # Automatic Jellyfin merge of duplicate movie versions (every N hours; 0 disables).
 MERGE_VERSIONS_INTERVAL_HOURS = _env_int("MERGE_VERSIONS_INTERVAL_HOURS", 6)
 

--- a/seerr.py
+++ b/seerr.py
@@ -19,3 +19,14 @@ def get_request(request_id: str | int, timeout: int = 10) -> dict:
     resp = requests.get(url, headers=_headers(), timeout=timeout)
     resp.raise_for_status()
     return resp.json() or {}
+
+
+def list_approved_requests(take: int = 20, skip: int = 0, timeout: int = 10) -> list[dict]:
+    if not SEERR_URL:
+        raise RuntimeError("SEERR_URL is not configured")
+    url = f"{SEERR_URL.rstrip('/')}/api/v1/request"
+    params = {"filter": "approved", "take": take, "skip": skip}
+    log.info("Fetching approved Seerr requests (take=%d skip=%d)", take, skip)
+    resp = requests.get(url, headers=_headers(), params=params, timeout=timeout)
+    resp.raise_for_status()
+    return (resp.json() or {}).get("results", [])

--- a/torbox.py
+++ b/torbox.py
@@ -49,6 +49,16 @@ def find_by_hash(info_hash: str) -> dict | None:
     return None
 
 
+def title_exists(title: str) -> bool:
+    """Return True if any torrent in mylist appears to match the given title."""
+    needle = title.lower()
+    for item in list_torrents():
+        name = (item.get("name") or "").lower()
+        if needle in name or name in needle:
+            return True
+    return False
+
+
 def _is_ready(item: dict) -> bool:
     if item.get("download_finished"):
         return True


### PR DESCRIPTION
On startup (after a configurable delay), the service fetches approved requests from Seerr and processes any that aren't already in TorBox.

**Flow:**
1. Wait `CATCHUP_DELAY_SEC` (30s) for the rest of the stack to come up
2. `GET /api/v1/request?filter=approved&take=20` from Seerr
3. Fetch TorBox `mylist` once (single API call for all checks)
4. For each request not matched in TorBox by title → call `processor.process()`

**New config:** `CATCHUP_ENABLED`, `CATCHUP_DELAY_SEC`, `CATCHUP_TAKE`
**New module:** `catchup.py`
**New helpers:** `seerr.list_approved_requests()`, `torbox.title_exists()`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AR9SX5oQyrorM81mNL1dzu)_