### PR TITLE
Add web dashboard at /ui with SQLite history and live logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ LISTEN_PORT=8088
 # or use the query param ?secret=<value>.
 WEBHOOK_SECRET=
 
+# SQLite database path (inside container). Mounted via docker-compose volumes: ./data:/data
+DB_PATH=/data/requests.db
+
 # Quality preferences — lower index = more preferred. 4K allowed, 1080p tried first.
 QUALITY_PREFERENCE=1080p,2160p,720p
 ALLOW_4K=true

--- a/app.py
+++ b/app.py
@@ -1,11 +1,14 @@
 import logging
+import re
 import threading
 
 from apscheduler.schedulers.background import BackgroundScheduler
-from flask import Flask, abort, jsonify, request
+from flask import Flask, abort, flash, jsonify, redirect, render_template, request, url_for
 
 import catchup
+import db
 import jellyfin
+import log_buffer
 import processor
 from config import (
     CATCHUP_ENABLED,
@@ -15,12 +18,16 @@ from config import (
     WEBHOOK_SECRET,
     configure_logging,
 )
-from webhook_parser import IgnoreEvent, WebhookError, parse
+from webhook_parser import IgnoreEvent, MediaRequest, WebhookError, parse
 
 configure_logging()
+log_buffer.install()
 log = logging.getLogger("seerr-torbox")
 
 app = Flask(__name__)
+app.secret_key = "seerr-torbox-ui"
+
+db.init()
 
 
 def _start_scheduler() -> BackgroundScheduler | None:
@@ -46,6 +53,8 @@ if CATCHUP_ENABLED:
     catchup.schedule()
 
 
+# ── Auth ──────────────────────────────────────────────────────────────────────
+
 def _check_auth() -> None:
     if not WEBHOOK_SECRET:
         return
@@ -54,6 +63,8 @@ def _check_auth() -> None:
         log.warning("Rejected webhook with bad/missing secret from %s", request.remote_addr)
         abort(401)
 
+
+# ── Webhook ───────────────────────────────────────────────────────────────────
 
 @app.get("/health")
 def health():
@@ -75,7 +86,6 @@ def webhook():
         log.error("Bad webhook payload: %s", exc)
         return jsonify(status="error", error=str(exc)), 400
 
-    # Run the long-running fulfillment off the request thread so Seerr gets a fast 200.
     thread = threading.Thread(
         target=processor.process,
         args=(media_request,),
@@ -84,6 +94,53 @@ def webhook():
     )
     thread.start()
     return jsonify(status="accepted", imdb_id=media_request.imdb_id, title=media_request.title), 202
+
+
+# ── Dashboard ─────────────────────────────────────────────────────────────────
+
+@app.get("/ui")
+def ui_dashboard():
+    rows = db.get_recent(100)
+    return render_template("ui.html", rows=rows)
+
+
+@app.post("/ui/submit")
+def ui_submit():
+    imdb_id = (request.form.get("imdb_id") or "").strip()
+    media_type = request.form.get("media_type", "movie")
+    seasons_raw = request.form.get("seasons", "1")
+
+    if not re.fullmatch(r"tt\d{6,10}", imdb_id):
+        flash("Invalid IMDB ID — must be tt followed by 6-10 digits.", "err")
+        return redirect(url_for("ui_dashboard"))
+    if media_type not in ("movie", "series"):
+        flash("Invalid media type.", "err")
+        return redirect(url_for("ui_dashboard"))
+
+    seasons = [int(s.strip()) for s in re.split(r"[,\s]+", seasons_raw) if s.strip().isdigit()]
+    if media_type == "series" and not seasons:
+        seasons = [1]
+
+    media_request = MediaRequest(
+        title=imdb_id,
+        media_type=media_type,
+        imdb_id=imdb_id,
+        seasons=seasons,
+    )
+    thread = threading.Thread(
+        target=processor.process,
+        args=(media_request,),
+        name=f"manual-{imdb_id}",
+        daemon=True,
+    )
+    thread.start()
+    flash(f"Request queued: {imdb_id} ({media_type})", "ok")
+    return redirect(url_for("ui_dashboard"))
+
+
+@app.get("/ui/logs")
+def ui_logs():
+    return jsonify(lines=log_buffer.get_lines(100))
 
 
 if __name__ == "__main__":

--- a/config.py
+++ b/config.py
@@ -59,6 +59,8 @@ TORBOX_POLL_TIMEOUT_SEC = _env_int("TORBOX_POLL_TIMEOUT_SEC", 600)
 
 WEBHOOK_SECRET = _env("WEBHOOK_SECRET", "")
 
+DB_PATH = _env("DB_PATH", "/data/requests.db")
+
 CATCHUP_ENABLED = _env("CATCHUP_ENABLED", "true").lower() in ("1", "true", "yes")
 CATCHUP_DELAY_SEC = _env_int("CATCHUP_DELAY_SEC", 30)
 CATCHUP_TAKE = _env_int("CATCHUP_TAKE", 20)

--- a/db.py
+++ b/db.py
@@ -1,0 +1,69 @@
+import sqlite3
+from config import DB_PATH
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS requests (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    title       TEXT    NOT NULL,
+    imdb_id     TEXT    NOT NULL,
+    media_type  TEXT    NOT NULL,
+    seasons     TEXT,
+    status      TEXT    NOT NULL DEFAULT 'pending',
+    quality     TEXT,
+    source      TEXT,
+    info_hash   TEXT,
+    error       TEXT,
+    created_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%S', 'now')),
+    updated_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%S', 'now'))
+)
+"""
+
+
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init() -> None:
+    with _connect() as conn:
+        conn.execute(_DDL)
+        conn.commit()
+
+
+def insert_request(title: str, imdb_id: str, media_type: str, seasons: list[int] | None = None) -> int:
+    seasons_str = ",".join(str(s) for s in (seasons or []))
+    with _connect() as conn:
+        cur = conn.execute(
+            "INSERT INTO requests (title, imdb_id, media_type, seasons) VALUES (?, ?, ?, ?)",
+            (title, imdb_id, media_type, seasons_str or None),
+        )
+        conn.commit()
+        return cur.lastrowid  # type: ignore[return-value]
+
+
+def update_request(
+    row_id: int,
+    status: str,
+    quality: str | None = None,
+    source: str | None = None,
+    info_hash: str | None = None,
+    error: str | None = None,
+) -> None:
+    with _connect() as conn:
+        conn.execute(
+            """UPDATE requests
+               SET status=?, quality=?, source=?, info_hash=?, error=?,
+                   updated_at=strftime('%Y-%m-%d %H:%M:%S', 'now')
+               WHERE id=?""",
+            (status, quality, source, info_hash, error, row_id),
+        )
+        conn.commit()
+
+
+def get_recent(limit: int = 100) -> list[dict]:
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT * FROM requests ORDER BY created_at DESC LIMIT ?", (limit,)
+        ).fetchall()
+        return [dict(r) for r in rows]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,5 @@ services:
     environment:
       - LISTEN_HOST=0.0.0.0
       - LISTEN_PORT=8088
+    volumes:
+      - ./data:/data

--- a/log_buffer.py
+++ b/log_buffer.py
@@ -1,0 +1,25 @@
+import logging
+from collections import deque
+
+_buffer: deque[str] = deque(maxlen=500)
+
+
+class _BufferHandler(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            _buffer.append(self.format(record))
+        except Exception:
+            pass
+
+
+_handler = _BufferHandler()
+_handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s [%(name)s] %(message)s"))
+
+
+def install() -> None:
+    logging.getLogger().addHandler(_handler)
+
+
+def get_lines(n: int = 100) -> list[str]:
+    lines = list(_buffer)
+    return lines[-n:]

--- a/processor.py
+++ b/processor.py
@@ -1,11 +1,14 @@
 import logging
 import time
+from typing import Optional
 
+import db
 import jellyfin
 import torbox
 import torrentio
 import zilean
 from config import JELLYFIN_REFRESH_DELAY_SEC, ZILEAN_ENABLED
+from torrentio import TorrentioStream
 from webhook_parser import MediaRequest
 
 log = logging.getLogger(__name__)
@@ -39,8 +42,10 @@ def _fetch_season_candidates(req: MediaRequest, season: int, episode: int, prefe
     return _rank(streams, prefer_season_pack=prefer_season_pack)
 
 
-def _add_best_from(candidates: list, label: str) -> bool:
-    """Check cache, prefer cached candidates, fall back to adding uncached if none cached."""
+def _add_best_from(candidates: list, label: str) -> tuple[bool, Optional[TorrentioStream]]:
+    """Check cache, prefer cached candidates, fall back to best uncached if none cached.
+    Returns (success, winning_stream).
+    """
     cached_hashes = torbox.check_cached([s.info_hash for s in candidates])
 
     cached = [s for s in candidates if s.info_hash in cached_hashes]
@@ -51,42 +56,43 @@ def _add_best_from(candidates: list, label: str) -> bool:
     else:
         log.info("No cached candidates for %s — will add best uncached", label)
 
-    # Try cached first (ranked order preserved); fall back to best uncached.
     for stream in (cached or uncached[:1]):
         try:
             torbox.add_magnet(stream.magnet)
             torbox.wait_until_ready(stream.info_hash)
-            return True
+            return True, stream
         except Exception as exc:
             log.warning(
                 "Failed to add %s (hash=%s quality=%s cached=%s): %s — trying next",
                 label, stream.info_hash, stream.quality, stream.info_hash in cached_hashes, exc,
             )
     log.error("All candidate(s) failed for %s", label)
-    return False
+    return False, None
 
 
-def _process_movie(req: MediaRequest) -> bool:
+def _process_movie(req: MediaRequest) -> tuple[bool, Optional[TorrentioStream]]:
     candidates = _fetch_movie_candidates(req)
     if not candidates:
         log.error("No suitable stream for movie %s (%s)", req.title, req.imdb_id)
-        return False
+        return False, None
     log.info("Trying %d candidate(s) for %s", len(candidates), req.title)
     return _add_best_from(candidates, req.title)
 
 
-def _process_season(req: MediaRequest, season: int) -> bool:
+def _process_season(req: MediaRequest, season: int) -> tuple[bool, Optional[TorrentioStream]]:
     pack_candidates = _fetch_season_candidates(req, season, episode=1, prefer_season_pack=True)
 
     if pack_candidates and pack_candidates[0].is_season_pack:
         log.info("Trying season pack(s) for %s S%02d", req.title, season)
         packs = [s for s in pack_candidates if s.is_season_pack]
-        if _add_best_from(packs, f"{req.title} S{season:02d} pack"):
-            return True
+        ok, winner = _add_best_from(packs, f"{req.title} S{season:02d} pack")
+        if ok:
+            return True, winner
         log.info("Season pack(s) failed; falling back to per-episode")
 
     log.info("Going per-episode for %s S%02d", req.title, season)
     added = 0
+    first_winner: Optional[TorrentioStream] = None
     episode = 1
     while True:
         if episode == 1:
@@ -96,31 +102,49 @@ def _process_season(req: MediaRequest, season: int) -> bool:
         if not candidates:
             log.info("No more episodes returned at S%02dE%02d", season, episode)
             break
-        if _add_best_from(candidates, f"{req.title} S{season:02d}E{episode:02d}"):
+        ok, winner = _add_best_from(candidates, f"{req.title} S{season:02d}E{episode:02d}")
+        if ok:
             added += 1
+            first_winner = first_winner or winner
         episode += 1
         if episode > 50:
             log.warning("Episode cap (50) reached for %s S%02d", req.title, season)
             break
-    return added > 0
+    return added > 0, first_winner
 
 
 def process(req: MediaRequest) -> bool:
     log.info("Processing request: %s [%s] %s", req.title, req.media_type, req.imdb_id)
+    row_id = db.insert_request(req.title, req.imdb_id, req.media_type, req.seasons)
     success = False
+    winner: Optional[TorrentioStream] = None
     try:
         if req.is_movie:
-            success = _process_movie(req)
+            success, winner = _process_movie(req)
         else:
             for season in req.seasons:
-                if _process_season(req, season):
+                ok, w = _process_season(req, season)
+                if ok:
                     success = True
-    finally:
-        if success:
-            if JELLYFIN_REFRESH_DELAY_SEC > 0:
-                log.info("Waiting %ds before triggering Jellyfin refresh", JELLYFIN_REFRESH_DELAY_SEC)
-                time.sleep(JELLYFIN_REFRESH_DELAY_SEC)
-            jellyfin.refresh_library()
-        else:
-            log.warning("No content added; skipping Jellyfin refresh for %s", req.title)
+                    winner = winner or w
+    except Exception as exc:
+        log.exception("Unexpected error processing %s", req.title)
+        db.update_request(row_id, "failed", error=str(exc))
+        return False
+
+    if success:
+        db.update_request(
+            row_id, "success",
+            quality=winner.quality if winner else None,
+            source=winner.name.split()[0] if winner else None,
+            info_hash=winner.info_hash if winner else None,
+        )
+        if JELLYFIN_REFRESH_DELAY_SEC > 0:
+            log.info("Waiting %ds before triggering Jellyfin refresh", JELLYFIN_REFRESH_DELAY_SEC)
+            time.sleep(JELLYFIN_REFRESH_DELAY_SEC)
+        jellyfin.refresh_library()
+    else:
+        db.update_request(row_id, "failed")
+        log.warning("No content added; skipping Jellyfin refresh for %s", req.title)
+
     return success

--- a/templates/ui.html
+++ b/templates/ui.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Seerr → TorBox</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, -apple-system, sans-serif; background: #0f1117; color: #cbd5e1; min-height: 100vh; padding: 24px; }
+    a { color: #818cf8; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 28px; }
+    header h1 { font-size: 22px; font-weight: 700; color: #e2e8f0; }
+    header h1 span { color: #818cf8; }
+    .refresh-hint { font-size: 12px; color: #475569; }
+
+    .section { margin-bottom: 32px; }
+    .section-title { font-size: 11px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; color: #64748b; margin-bottom: 12px; }
+
+    /* Manual form */
+    form { display: flex; flex-wrap: wrap; gap: 10px; align-items: flex-end; }
+    .field { display: flex; flex-direction: column; gap: 4px; }
+    label { font-size: 11px; color: #64748b; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; }
+    input, select {
+      background: #1e2535; border: 1px solid #2d3a4e; color: #e2e8f0;
+      padding: 8px 12px; border-radius: 6px; font-size: 14px; outline: none;
+      transition: border-color .15s;
+    }
+    input:focus, select:focus { border-color: #818cf8; }
+    input[name="imdb_id"] { width: 160px; }
+    input[name="seasons"] { width: 140px; }
+    button[type="submit"] {
+      background: #4f46e5; color: #fff; border: none; padding: 9px 20px;
+      border-radius: 6px; font-size: 14px; font-weight: 600; cursor: pointer;
+      transition: background .15s;
+    }
+    button[type="submit"]:hover { background: #4338ca; }
+
+    /* Flash message */
+    .flash { padding: 10px 14px; border-radius: 6px; margin-bottom: 16px; font-size: 13px; }
+    .flash-ok  { background: #052e16; color: #4ade80; border: 1px solid #166534; }
+    .flash-err { background: #2d0a0a; color: #f87171; border: 1px solid #7f1d1d; }
+
+    /* Table */
+    .table-wrap { overflow-x: auto; border-radius: 8px; border: 1px solid #1e2535; }
+    table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    thead tr { background: #161d2e; }
+    th { padding: 10px 14px; text-align: left; font-size: 11px; font-weight: 700;
+         text-transform: uppercase; letter-spacing: .06em; color: #475569; white-space: nowrap; }
+    tbody tr { border-top: 1px solid #1a2236; transition: background .1s; }
+    tbody tr:hover { background: #1a2236; }
+    td { padding: 10px 14px; vertical-align: middle; }
+    .empty { text-align: center; color: #334155; padding: 32px !important; }
+
+    /* Badges */
+    .badge { display: inline-block; padding: 2px 9px; border-radius: 9999px; font-size: 11px; font-weight: 700; white-space: nowrap; }
+    .badge-success { background: #052e16; color: #4ade80; }
+    .badge-failed  { background: #2d0a0a; color: #f87171; }
+    .badge-pending { background: #2d1b00; color: #fbbf24; }
+
+    .mono { font-family: monospace; font-size: 12px; color: #94a3b8; }
+    .dim  { color: #475569; font-size: 12px; }
+
+    /* Log box */
+    #log-box {
+      background: #090d14; border: 1px solid #1a2236; border-radius: 8px;
+      padding: 14px 16px; font-family: monospace; font-size: 12px; line-height: 1.6;
+      max-height: 340px; overflow-y: auto; white-space: pre-wrap; color: #7dd3fc;
+    }
+    .log-controls { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
+    .log-status { font-size: 11px; color: #475569; }
+    #log-toggle { background: #1e2535; border: 1px solid #2d3a4e; color: #94a3b8;
+                  padding: 4px 10px; border-radius: 4px; font-size: 12px; cursor: pointer; }
+
+    .stats { display: flex; gap: 16px; margin-bottom: 24px; }
+    .stat { background: #161d2e; border: 1px solid #1e2535; border-radius: 8px; padding: 14px 20px; flex: 1; min-width: 100px; }
+    .stat-value { font-size: 24px; font-weight: 700; color: #e2e8f0; }
+    .stat-label { font-size: 11px; color: #475569; margin-top: 2px; text-transform: uppercase; letter-spacing: .05em; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Seerr <span>→</span> TorBox</h1>
+    <span class="refresh-hint">Page auto-refreshes every 30s</span>
+  </header>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% for cat, msg in messages %}
+      <div class="flash flash-{{ cat }}">{{ msg }}</div>
+    {% endfor %}
+  {% endwith %}
+
+  <!-- Stats -->
+  <div class="stats">
+    <div class="stat">
+      <div class="stat-value">{{ rows | selectattr('status','eq','success') | list | length }}</div>
+      <div class="stat-label">Succeeded</div>
+    </div>
+    <div class="stat">
+      <div class="stat-value">{{ rows | selectattr('status','eq','pending') | list | length }}</div>
+      <div class="stat-label">Pending</div>
+    </div>
+    <div class="stat">
+      <div class="stat-value">{{ rows | selectattr('status','eq','failed') | list | length }}</div>
+      <div class="stat-label">Failed</div>
+    </div>
+    <div class="stat">
+      <div class="stat-value">{{ rows | length }}</div>
+      <div class="stat-label">Total</div>
+    </div>
+  </div>
+
+  <!-- Manual request form -->
+  <div class="section">
+    <div class="section-title">Manual Request</div>
+    <form method="post" action="/ui/submit">
+      <div class="field">
+        <label>IMDB ID</label>
+        <input name="imdb_id" placeholder="tt0293662" required pattern="tt\d{6,10}">
+      </div>
+      <div class="field">
+        <label>Type</label>
+        <select name="media_type">
+          <option value="movie">Movie</option>
+          <option value="series">Series</option>
+        </select>
+      </div>
+      <div class="field">
+        <label>Seasons (series only)</label>
+        <input name="seasons" placeholder="1  or  1,2,3" value="1">
+      </div>
+      <div class="field">
+        <label>&nbsp;</label>
+        <button type="submit">Add to TorBox</button>
+      </div>
+    </form>
+  </div>
+
+  <!-- Request history table -->
+  <div class="section">
+    <div class="section-title">Recent Requests</div>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>IMDB</th>
+            <th>Type</th>
+            <th>Seasons</th>
+            <th>Status</th>
+            <th>Quality</th>
+            <th>Source</th>
+            <th>Added</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in rows %}
+          <tr>
+            <td>{{ row.title }}</td>
+            <td><a href="https://www.imdb.com/title/{{ row.imdb_id }}" target="_blank">{{ row.imdb_id }}</a></td>
+            <td class="dim">{{ row.media_type }}</td>
+            <td class="dim">{{ row.seasons or '—' }}</td>
+            <td><span class="badge badge-{{ row.status }}">{{ row.status }}</span></td>
+            <td class="mono">{{ row.quality or '—' }}</td>
+            <td class="dim">{{ row.source or '—' }}</td>
+            <td class="dim">{{ row.created_at }}</td>
+          </tr>
+          {% else %}
+          <tr><td colspan="8" class="empty">No requests yet</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- Live logs -->
+  <div class="section">
+    <div class="section-title">Live Logs</div>
+    <div class="log-controls">
+      <button id="log-toggle" onclick="toggleAuto()">Auto-refresh: ON</button>
+      <span class="log-status" id="log-status">Loading…</span>
+    </div>
+    <div id="log-box">Loading…</div>
+  </div>
+
+  <script>
+    let autoRefresh = true;
+    let logTimer = null;
+
+    function toggleAuto() {
+      autoRefresh = !autoRefresh;
+      document.getElementById('log-toggle').textContent = 'Auto-refresh: ' + (autoRefresh ? 'ON' : 'OFF');
+      if (autoRefresh) scheduleLogs();
+      else clearTimeout(logTimer);
+    }
+
+    async function fetchLogs() {
+      try {
+        const r = await fetch('/ui/logs');
+        const data = await r.json();
+        const box = document.getElementById('log-box');
+        const atBottom = box.scrollHeight - box.scrollTop <= box.clientHeight + 40;
+        box.textContent = data.lines.join('\n');
+        if (atBottom) box.scrollTop = box.scrollHeight;
+        document.getElementById('log-status').textContent =
+          data.lines.length + ' lines · ' + new Date().toLocaleTimeString();
+      } catch(e) {
+        document.getElementById('log-status').textContent = 'fetch failed';
+      }
+    }
+
+    function scheduleLogs() {
+      clearTimeout(logTimer);
+      logTimer = setTimeout(async () => {
+        await fetchLogs();
+        if (autoRefresh) scheduleLogs();
+      }, 5000);
+    }
+
+    // Page auto-refresh every 30s for the table
+    setTimeout(() => location.reload(), 30000);
+
+    fetchLogs();
+    scheduleLogs();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## What's included

**`db.py`** — SQLite (`/data/requests.db`) with `requests` table tracking title, IMDB ID, type, seasons, status, quality, source, info_hash, timestamps.

**`log_buffer.py`** — In-memory circular buffer (500 lines) installed as a logging handler; served via `/ui/logs`.

**`templates/ui.html`** — Self-contained dark dashboard (no external CDN):
- Stats row: succeeded / pending / failed / total
- Manual request form: IMDB ID + movie/series + seasons
- Request history table with colour-coded status badges
- Live log viewer (JS fetch every 5s, auto-scroll, toggle)
- Page auto-reloads every 30s for fresh table data

**`app.py`** routes added:
- `GET /ui` — dashboard
- `POST /ui/submit` — queues a manual request
- `GET /ui/logs` — returns last 100 log lines as JSON

**`processor.py`** — Records each request as `pending` on start, updates to `success` (with quality/source/hash) or `failed` on completion.

**`docker-compose.yml`** — Adds `./data:/data` volume so the DB survives container restarts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AR9SX5oQyrorM81mNL1dzu)_